### PR TITLE
Disallow unknown tags, throw error instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+debug.test

--- a/decode.go
+++ b/decode.go
@@ -647,11 +647,21 @@ func (d *decoder) mappingSlice(n *node, out reflect.Value) (good bool) {
 	mapType := d.mapType
 	d.mapType = outt
 
-	var slice []MapItem
-	var l = len(n.children)
-	for i := 0; i < l; i += 2 {
+	var keys []interface{}
+	kv := make(map[interface{}]interface{})
+
+	for i := 0; i < len(n.children); i += 2 {
 		if isMerge(n.children[i]) {
 			d.merge(n.children[i+1], out)
+			for i := 0; i < out.Len(); i++ {
+				item := out.Index(i).Interface().(MapItem)
+				_, ok := kv[item.Key]
+				kv[item.Key] = item.Value
+				if !ok {
+					keys = append(keys, item.Key)
+				}
+			}
+
 			continue
 		}
 		item := MapItem{}
@@ -659,11 +669,19 @@ func (d *decoder) mappingSlice(n *node, out reflect.Value) (good bool) {
 		if d.unmarshal(n.children[i], k) {
 			v := reflect.ValueOf(&item.Value).Elem()
 			if d.unmarshal(n.children[i+1], v) {
-				slice = append(slice, item)
+				_, ok := kv[item.Key]
+				kv[item.Key] = item.Value
+				if !ok {
+					keys = append(keys, item.Key)
+				}
 			}
 		}
 	}
-	out.Set(reflect.ValueOf(slice))
+	var output []MapItem
+	for _, key := range keys {
+		output = append(output, MapItem{key, kv[key]})
+	}
+	out.Set(reflect.ValueOf(output))
 	d.mapType = mapType
 	return true
 }
@@ -741,6 +759,30 @@ func (d *decoder) merge(n *node, out reflect.Value) {
 		}
 		d.unmarshal(n, out)
 	case sequenceNode:
+		if out.Kind() == reflect.Slice {
+			kv := make(map[interface{}]interface{})
+			var keys []interface{}
+			for i := len(n.children) - 1; i >= 0; i-- {
+				d.unmarshal(n.children[i], out)
+				var subitems []interface{}
+				for j := 0; j < out.Len(); j++ {
+					item := out.Index(j).Interface().(MapItem)
+					_, ok := kv[item.Key]
+					kv[item.Key] = item.Value
+					if !ok {
+						subitems = append(subitems, item.Key)
+					}
+				}
+				keys = append(subitems, keys...)
+			}
+			var output []MapItem
+			for _, key := range keys {
+				output = append(output, MapItem{key, kv[key]})
+			}
+			out.Set(reflect.ValueOf(output))
+			return
+		}
+
 		// Step backwards as earlier nodes take precedence.
 		for i := len(n.children) - 1; i >= 0; i-- {
 			ni := n.children[i]
@@ -754,9 +796,11 @@ func (d *decoder) merge(n *node, out reflect.Value) {
 			}
 			d.unmarshal(ni, out)
 		}
+
 	default:
 		failWantMap()
 	}
+
 }
 
 func isMerge(n *node) bool {

--- a/decode_test.go
+++ b/decode_test.go
@@ -1242,6 +1242,29 @@ func (t *textUnmarshaler) UnmarshalText(s []byte) error {
 	return nil
 }
 
+//It is interesting for users to have an alias to implement custom interface methods
+type TestCustomMapSlice yaml.MapSlice
+
+func (s *S) TestMergeCustomMapSlice(c *C) {
+	container := TestCustomMapSlice{}
+	err := yaml.Unmarshal([]byte(mergeTests), &container)
+	c.Check(err, IsNil)
+
+	var want = TestCustomMapSlice{
+		yaml.MapItem{Key: "x", Value: 1},
+		yaml.MapItem{Key: "y", Value: 2},
+		yaml.MapItem{Key: "r", Value: 10},
+		yaml.MapItem{Key: "label", Value: "center/big"},
+	}
+
+	for _, test := range container {
+		if test.Key == "anchors" {
+			continue
+		}
+		c.Assert(test.Value, DeepEquals, want, Commentf("test %q failed", test))
+	}
+}
+
 //var data []byte
 //func init() {
 //	var err error

--- a/decode_test.go
+++ b/decode_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/buildkite/yaml"
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
 )
 
 var unmarshalIntTest = 123

--- a/encode_test.go
+++ b/encode_test.go
@@ -11,8 +11,8 @@ import (
 	"net"
 	"os"
 
+	"github.com/buildkite/yaml"
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
 )
 
 var marshalIntTest = 123

--- a/example_embedded_test.go
+++ b/example_embedded_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"gopkg.in/yaml.v2"
+	"github.com/buildkite/yaml"
 )
 
 // An example showing how to unmarshal embedded

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
-module "gopkg.in/yaml.v2"
+module github.com/buildkite/yaml
 
-require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
-)
+require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/parserc.go
+++ b/parserc.go
@@ -2,6 +2,7 @@ package yaml
 
 import (
 	"bytes"
+	"fmt"
 )
 
 // The parser implements the following grammar:
@@ -441,6 +442,9 @@ func yaml_parser_parse_node(parser *yaml_parser_t, event *yaml_event_t, block, i
 				}
 			}
 			if len(tag) == 0 {
+				if bytes.Equal(tag_handle, []byte("!")) {
+					return yaml_parser_set_parser_error(parser, fmt.Sprintf("found an undefined tag, did you mean to quote it? !%s -> '!%s'", tag_suffix, tag_suffix), tag_mark)
+				}
 				yaml_parser_set_parser_error_context(parser,
 					"while parsing a node", start_mark,
 					"found undefined tag handle", tag_mark)
@@ -1005,7 +1009,6 @@ func yaml_parser_process_empty_scalar(parser *yaml_parser_t, event *yaml_event_t
 }
 
 var default_tag_directives = []yaml_tag_directive_t{
-	{[]byte("!"), []byte("!")},
 	{[]byte("!!"), []byte("tag:yaml.org,2002:")},
 }
 

--- a/suite_test.go
+++ b/suite_test.go
@@ -1,8 +1,9 @@
 package yaml_test
 
 import (
-	. "gopkg.in/check.v1"
 	"testing"
+
+	. "gopkg.in/check.v1"
 )
 
 func Test(t *testing.T) { TestingT(t) }


### PR DESCRIPTION
Fixes buildkite/agent#1283

Since the Buildkite agent uses its own fork of go-yaml, we can change the behaviour when it encounters an undefined tag. Now it will throw an error during parsing, and the error message hints at a possible fix.

I think it's preferable to fail with an error here rather than just a warning, as it helps prevent jobs running on the wrong branches.

However, this approach will fail for _any pipeline file that has an undefined tag_, not just for the `branches` rule. I'd consider this a fairly low risk since I haven't seen tags used for Buildkite pipelines anywhere, but guidance is appreciated.

I've tried running my changes with a local build of the agent, you can see [an example of the output on the dashboard](https://buildkite.com/nchlswhttkr/buildkite-tag-test/builds?branch=main).

Cheers, happy Hacktoberfest!